### PR TITLE
Skip guise function when Neovim runs with --headless

### DIFF
--- a/plugin/guise.vim
+++ b/plugin/guise.vim
@@ -8,6 +8,15 @@ if empty(s:address)
   finish
 endif
 
+" Skip guise if Neovim is running in headless mode
+if has('nvim') && exists('v:argv')
+  for arg in v:argv
+    if arg ==# '--headless'
+      finish
+    endif
+  endfor
+endif
+
 augroup guise_plugin_internal
   autocmd!
   autocmd SwapExists * let v:swapchoice = 'o'


### PR DESCRIPTION
## Summary
- Added check for `--headless` flag in Neovim's command-line arguments
- Plugin now exits early when headless mode is detected, preventing guise from running
- Allows Neovim to work properly in automated/CI environments

## Test plan
- [ ] Launch Neovim normally and verify guise still works
- [ ] Launch Neovim with `nvim --headless` and verify guise is skipped
- [ ] Verify no errors occur in headless mode

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents the plugin from loading in headless Neovim sessions, avoiding unintended initialization during CI/automation and command-line usage.
  * Improves startup behavior in headless environments by skipping unnecessary setup, reducing potential side effects and speeding up non-interactive runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->