### PR TITLE
[codex] strict target buffer for BufWipeout

### DIFF
--- a/denops/guise/editor.ts
+++ b/denops/guise/editor.ts
@@ -32,8 +32,16 @@ export async function open(denops: Denops): Promise<void> {
     await group(denops, auname, (helper) => {
       helper.remove();
       helper.define(
-        ["BufWipeout", "VimLeave"],
+        ["VimLeave"],
         "*",
+        `call denops#request('${denops.name}', '${lambda.id}', [])`,
+        {
+          once: true,
+        },
+      );
+      helper.define(
+        ["BufWipeout"],
+        "<buffer=abuf>",
         `call denops#request('${denops.name}', '${lambda.id}', [])`,
         {
           once: true,
@@ -73,8 +81,16 @@ export async function edit(denops: Denops, filename: string): Promise<void> {
     await group(denops, auname, (helper) => {
       helper.remove();
       helper.define(
-        ["BufWipeout", "VimLeave"],
+        ["VimLeave"],
         "*",
+        `call denops#request('${denops.name}', '${lambda.id}', [])`,
+        {
+          once: true,
+        },
+      );
+      helper.define(
+        ["BufWipeout"],
+        "<buffer=abuf>",
         `call denops#request('${denops.name}', '${lambda.id}', [])`,
         {
           once: true,

--- a/denops/guise/editor.ts
+++ b/denops/guise/editor.ts
@@ -41,7 +41,7 @@ export async function open(denops: Denops): Promise<void> {
       );
       helper.define(
         ["BufWipeout"],
-        "<buffer=abuf>",
+        `<buffer=${bufnrVal}>`,
         `call denops#request('${denops.name}', '${lambda.id}', [])`,
         {
           once: true,
@@ -90,7 +90,7 @@ export async function edit(denops: Denops, filename: string): Promise<void> {
       );
       helper.define(
         ["BufWipeout"],
-        "<buffer=abuf>",
+        `<buffer=${bufnrVal}>`,
         `call denops#request('${denops.name}', '${lambda.id}', [])`,
         {
           once: true,


### PR DESCRIPTION
# Summary

BufWipeout の終了判定を対象バッファに限定し、他のバッファがバックグラウンドで wipe されたときに guise が誤終了しないようにしました。

# Root Cause

`BufWipeout *` 相当の広い判定になっていたため、LSP の floating window など別バッファの wipeout でも wait 終了が発火していました。

# Impact

- scratch buffer / edit buffer の終了待ちが、対象外バッファの wipe で中断されなくなる
- LSP の floating window 再生成に伴う誤終了を防ぐ

# Validation

- `make fmt-check`
- `make lint`
- `make type-check` では外部 JSR 依存の取得で失敗（`@std/semver@1.0.7_meta.json` のキャッシュ取得失敗）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer cleanup behavior when exiting or closing an editor session, helping ensure requests are triggered reliably in both cases.
  * Made shutdown handling more consistent by treating window close and application exit as separate events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->